### PR TITLE
Make list focusable.

### DIFF
--- a/library/src/main/res/layout/nnf_filepicker_listitem_checkable.xml
+++ b/library/src/main/res/layout/nnf_filepicker_listitem_checkable.xml
@@ -18,10 +18,14 @@
   -->
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/nnf_item_container"
     android:layout_width="match_parent"
     android:layout_height="?android:listPreferredItemHeight"
     android:background="?android:selectableItemBackground"
+    android:focusable="true"
     android:minHeight="?android:listPreferredItemHeight"
+    android:nextFocusLeft="@+id/nnf_button_cancel"
+    android:nextFocusRight="@id/checkbox"
     android:orientation="horizontal">
 
 
@@ -48,12 +52,14 @@
         android:maxLines="1"
         android:padding="8dp"
         android:singleLine="true"
-        android:text="@string/nnf_name"/>
+        android:text="@string/nnf_name" />
 
     <CheckBox
         android:id="@+id/checkbox"
         android:layout_width="wrap_content"
         android:layout_height="match_parent"
+        android:nextFocusLeft="@id/nnf_item_container"
+        android:nextFocusRight="@+id/nnf_button_ok"
         android:paddingEnd="8dp"
         android:paddingRight="8dp"
         tools:ignore="RtlSymmetry" />

--- a/library/src/main/res/layout/nnf_filepicker_listitem_dir.xml
+++ b/library/src/main/res/layout/nnf_filepicker_listitem_dir.xml
@@ -18,12 +18,15 @@
   -->
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/nnf_item_container"
     android:layout_width="match_parent"
     android:layout_height="?android:listPreferredItemHeight"
     android:background="?android:selectableItemBackground"
+    android:focusable="true"
     android:minHeight="?android:listPreferredItemHeight"
-    android:orientation="horizontal"
-    >
+    android:nextFocusLeft="@+id/nnf_button_cancel"
+    android:nextFocusRight="@+id/nnf_button_ok"
+    android:orientation="horizontal">
 
     <!--suppress AndroidDomInspection -->
     <ImageView
@@ -48,5 +51,5 @@
         android:maxLines="1"
         android:padding="8dp"
         android:singleLine="true"
-        android:text="@string/nnf_name"/>
+        android:text="@string/nnf_name" />
 </LinearLayout>

--- a/library/src/main/res/layout/nnf_fragment_filepicker.xml
+++ b/library/src/main/res/layout/nnf_fragment_filepicker.xml
@@ -47,6 +47,8 @@
         android:layout_height="wrap_content"
         android:layout_above="@+id/nnf_button_container"
         android:layout_below="@+id/nnf_picker_toolbar"
+        android:descendantFocusability="afterDescendants"
+        android:focusable="true"
         tools:listitem="@layout/nnf_filepicker_listitem_dir" />
 
     <LinearLayout


### PR DESCRIPTION
Appears to make the filepicker usable in non-touch screen environments
(e.g. D-Pad).

Fixes #44