### PR TITLE
Make click events overridable

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ repositories {
 }
 
 dependencies {
-    compile 'com.nononsenseapps:filepicker:2.3.1'
+    compile 'com.nononsenseapps:filepicker:2.4.0'
 }
 ```
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -17,8 +17,8 @@
 
 # Project-wide Gradle settings.
 
-VERSION_NAME=2.3.1
-VERSION_CODE=22
+VERSION_NAME=2.4.0
+VERSION_CODE=23
 GROUP=com.nononsenseapps
 
 PROJECT_NAME=com.nononsenseapps:filepicker

--- a/library/src/main/res/values/strings.xml
+++ b/library/src/main/res/values/strings.xml
@@ -16,7 +16,6 @@
   -->
 
 <resources>
-    <string name="nnf_app_name">NoNonsense File Picker</string>
     <string name="nnf_new_folder">New folder</string>
     <string name="nnf_create_folder_error">Failed to create folder</string>
     <string name="nnf_name">Name</string>

--- a/release-notes.md
+++ b/release-notes.md
@@ -1,3 +1,21 @@
+# 2.4.0
+- Added additional methods in AbstractFilePickerFragment to allow more
+  customized behavior. All methods have default behavior, but can be augmented
+  by child classes.:
+  
+  goUp, navigates to parent directory.
+  goToDir, navigates to specified directory.
+  onClickOK, handles ok button.
+  onClickCancel, handles cancel button.
+  onClickHeader, handles clicks on "..".
+  onClickDir, handles clicks on non-selectable items (usually directories).
+  onLongClickDir, handles long clicks on non-selectable items.
+  onClickCheckable, handles clicks on selectable items.
+  onLongClickCheckable, handles long clicks on selectable items.
+  onClickCheckBox, handles clicks on the checkbox of selectable items.
+
+  Please see default implementation and docstrings before overriding them.
+
 # 2.3.1
 - Library should work correctly with non-touch controls like directional pads
   or keyboards.


### PR DESCRIPTION
- Added additional methods in AbstractFilePickerFragment to allow more
  customized behavior. All methods have default behavior, but can be augmented
  by child classes.:
  
  goUp, navigates to parent directory.
  goToDir, navigates to specified directory.
  onClickOK, handles ok button.
  onClickCancel, handles cancel button.
  onClickHeader, handles clicks on "..".
  onClickDir, handles clicks on non-selectable items (usually directories).
  onLongClickDir, handles long clicks on non-selectable items.
  onClickCheckable, handles clicks on selectable items.
  onLongClickCheckable, handles long clicks on selectable items.
  onClickCheckBox, handles clicks on the checkbox of selectable items.

  Please see default implementation and docstrings before overriding them.