### PR TITLE
Ability to specify new file name

### DIFF
--- a/library/src/main/java/com/nononsenseapps/filepicker/AbstractFilePickerActivity.java
+++ b/library/src/main/java/com/nononsenseapps/filepicker/AbstractFilePickerActivity.java
@@ -57,6 +57,8 @@ public abstract class AbstractFilePickerActivity<T> extends AppCompatActivity
     public static final String EXTRA_MODE = "nononsense.intent.MODE";
     public static final String EXTRA_ALLOW_CREATE_DIR =
             "nononsense.intent" + ".ALLOW_CREATE_DIR";
+    public static final String EXTRA_ALLOW_CREATE_FILE =
+            "nononsense.intent" + ".ALLOW_CREATE_FILE";
     // For compatibility
     public static final String EXTRA_ALLOW_MULTIPLE =
             "android.intent.extra" + ".ALLOW_MULTIPLE";
@@ -69,6 +71,7 @@ public abstract class AbstractFilePickerActivity<T> extends AppCompatActivity
     protected String startPath = null;
     protected int mode = AbstractFilePickerFragment.MODE_FILE;
     protected boolean allowCreateDir = false;
+    protected boolean allowCreateFile = false;
     protected boolean allowMultiple = false;
 
     @Override
@@ -84,6 +87,8 @@ public abstract class AbstractFilePickerActivity<T> extends AppCompatActivity
             mode = intent.getIntExtra(EXTRA_MODE, mode);
             allowCreateDir = intent.getBooleanExtra(EXTRA_ALLOW_CREATE_DIR,
                     allowCreateDir);
+            allowCreateFile = intent.getBooleanExtra(EXTRA_ALLOW_CREATE_FILE,
+                    allowCreateFile);
             allowMultiple =
                     intent.getBooleanExtra(EXTRA_ALLOW_MULTIPLE, allowMultiple);
         }
@@ -94,7 +99,7 @@ public abstract class AbstractFilePickerActivity<T> extends AppCompatActivity
 
         if (fragment == null) {
             fragment =
-                    getFragment(startPath, mode, allowMultiple, allowCreateDir);
+                    getFragment(startPath, mode, allowMultiple, allowCreateDir, allowCreateFile);
         }
 
         if (fragment != null) {
@@ -108,7 +113,7 @@ public abstract class AbstractFilePickerActivity<T> extends AppCompatActivity
 
     protected abstract AbstractFilePickerFragment<T> getFragment(
             @Nullable final String startPath, final int mode, final boolean allowMultiple,
-            final boolean allowCreateDir);
+            final boolean allowCreateDir, final boolean allowCreateFile);
 
     @Override
     public void onSaveInstanceState(Bundle b) {

--- a/library/src/main/java/com/nononsenseapps/filepicker/AbstractFilePickerFragment.java
+++ b/library/src/main/java/com/nononsenseapps/filepicker/AbstractFilePickerFragment.java
@@ -44,7 +44,7 @@ import java.util.List;
  */
 public abstract class AbstractFilePickerFragment<T> extends Fragment
         implements LoaderManager.LoaderCallbacks<SortedList<T>>,
-        NewItemFragment.OnNewFolderListener, LogicHandler<T> {
+        NewItemFragment.OnNewItemListener, LogicHandler<T> {
 
     // The different preset modes of operation. This impacts the behaviour
     // and possible actions in the UI.
@@ -57,6 +57,8 @@ public abstract class AbstractFilePickerFragment<T> extends Fragment
     public static final String KEY_MODE = "KEY_MODE";
     // If it should be possible to create directories.
     public static final String KEY_ALLOW_DIR_CREATE = "KEY_ALLOW_DIR_CREATE";
+    // If it should be possible to create files.
+    public static final String KEY_ALLOW_FILE_CREATE = "KEY_ALLOW_FILE_CREATE";
     // Allow multiple items to be selected.
     public static final String KEY_ALLOW_MULTIPLE = "KEY_ALLOW_MULTIPLE";
     // Used for saving state.
@@ -66,6 +68,7 @@ public abstract class AbstractFilePickerFragment<T> extends Fragment
     protected int mode = MODE_FILE;
     protected T mCurrentPath = null;
     protected boolean allowCreateDir = false;
+    protected boolean allowCreateFile = false;
     protected boolean allowMultiple = false;
     protected OnFilePickedListener mListener;
     protected FileItemAdapter<T> mAdapter = null;
@@ -110,7 +113,8 @@ public abstract class AbstractFilePickerFragment<T> extends Fragment
      * @param allowDirCreate can new directories be created?
      */
     public void setArgs(@Nullable final String startPath, final int mode,
-                        final boolean allowMultiple, final boolean allowDirCreate) {
+                        final boolean allowMultiple, final boolean allowDirCreate,
+                        final boolean allowFileCreate) {
         // There might have been arguments set elsewhere, if so do not overwrite them.
         Bundle b = getArguments();
         if (b == null) {
@@ -121,6 +125,7 @@ public abstract class AbstractFilePickerFragment<T> extends Fragment
             b.putString(KEY_START_PATH, startPath);
         }
         b.putBoolean(KEY_ALLOW_DIR_CREATE, allowDirCreate);
+        b.putBoolean(KEY_ALLOW_FILE_CREATE, allowFileCreate);
         b.putBoolean(KEY_ALLOW_MULTIPLE, allowMultiple);
         b.putInt(KEY_MODE, mode);
         setArguments(b);
@@ -299,6 +304,8 @@ public abstract class AbstractFilePickerFragment<T> extends Fragment
                 mode = savedInstanceState.getInt(KEY_MODE, mode);
                 allowCreateDir = savedInstanceState
                         .getBoolean(KEY_ALLOW_DIR_CREATE, allowCreateDir);
+                allowCreateFile = savedInstanceState
+                        .getBoolean(KEY_ALLOW_FILE_CREATE, allowCreateFile);
                 allowMultiple = savedInstanceState
                         .getBoolean(KEY_ALLOW_MULTIPLE, allowMultiple);
 
@@ -310,6 +317,8 @@ public abstract class AbstractFilePickerFragment<T> extends Fragment
                 mode = getArguments().getInt(KEY_MODE, mode);
                 allowCreateDir = getArguments()
                         .getBoolean(KEY_ALLOW_DIR_CREATE, allowCreateDir);
+                allowCreateFile = getArguments()
+                        .getBoolean(KEY_ALLOW_FILE_CREATE, allowCreateFile);
                 allowMultiple = getArguments()
                         .getBoolean(KEY_ALLOW_MULTIPLE, allowMultiple);
                 if (getArguments().containsKey(KEY_START_PATH)) {
@@ -334,6 +343,8 @@ public abstract class AbstractFilePickerFragment<T> extends Fragment
 
         MenuItem item = menu.findItem(R.id.nnf_action_createdir);
         item.setVisible(allowCreateDir);
+        MenuItem itemFile = menu.findItem(R.id.nnf_action_createfile);
+        itemFile.setVisible(allowCreateFile);
     }
 
     @Override
@@ -342,6 +353,13 @@ public abstract class AbstractFilePickerFragment<T> extends Fragment
             Activity activity = getActivity();
             if (activity instanceof AppCompatActivity) {
                 NewFolderFragment.showDialog(((AppCompatActivity) activity).getSupportFragmentManager(),
+                        AbstractFilePickerFragment.this);
+            }
+            return true;
+        } else if (R.id.nnf_action_createfile == menuItem.getItemId()) {
+            Activity activity = getActivity();
+            if (activity instanceof AppCompatActivity) {
+                NewFileFragment.showDialog(((AppCompatActivity) activity).getSupportFragmentManager(),
                         AbstractFilePickerFragment.this);
             }
             return true;
@@ -357,6 +375,7 @@ public abstract class AbstractFilePickerFragment<T> extends Fragment
         b.putString(KEY_CURRENT_PATH, mCurrentPath.toString());
         b.putBoolean(KEY_ALLOW_MULTIPLE, allowMultiple);
         b.putBoolean(KEY_ALLOW_DIR_CREATE, allowCreateDir);
+        b.putBoolean(KEY_ALLOW_FILE_CREATE, allowCreateFile);
         b.putInt(KEY_MODE, mode);
     }
 

--- a/library/src/main/java/com/nononsenseapps/filepicker/FilePickerActivity.java
+++ b/library/src/main/java/com/nononsenseapps/filepicker/FilePickerActivity.java
@@ -23,11 +23,11 @@ public class FilePickerActivity extends AbstractFilePickerActivity<File> {
     @Override
     protected AbstractFilePickerFragment<File> getFragment(
             @Nullable final String startPath, final int mode, final boolean allowMultiple,
-            final boolean allowCreateDir) {
+            final boolean allowCreateDir, final boolean allowCreateFile) {
         AbstractFilePickerFragment<File> fragment = new FilePickerFragment();
         // startPath is allowed to be null. In that case, default folder should be SD-card and not "/"
         fragment.setArgs(startPath != null ? startPath : Environment.getExternalStorageDirectory().getPath(),
-                mode, allowMultiple, allowCreateDir);
+                mode, allowMultiple, allowCreateDir, allowCreateFile);
         return fragment;
     }
 }

--- a/library/src/main/java/com/nononsenseapps/filepicker/FilePickerFragment.java
+++ b/library/src/main/java/com/nononsenseapps/filepicker/FilePickerFragment.java
@@ -303,14 +303,18 @@ public class FilePickerFragment extends AbstractFilePickerFragment<File> {
      * @param name The name of the folder the user wishes to create.
      */
     @Override
-    public void onNewFolder(@NonNull final String name) {
-        File folder = new File(mCurrentPath, name);
-
-        if (folder.mkdir()) {
-            refresh(folder);
+    public void onNewItem(@NonNull final String name, final boolean isFile) {
+        if (isFile) {
+            mListener.onFilePicked(toUri(new File(mCurrentPath, name)));
         } else {
-            Toast.makeText(getActivity(), R.string.nnf_create_folder_error,
-                    Toast.LENGTH_SHORT).show();
+            File folder = new File(mCurrentPath, name);
+
+            if (folder.mkdir()) {
+                refresh(folder);
+            } else {
+                Toast.makeText(getActivity(), R.string.nnf_create_folder_error,
+                        Toast.LENGTH_SHORT).show();
+            }
         }
     }
 

--- a/library/src/main/java/com/nononsenseapps/filepicker/NewFileFragment.java
+++ b/library/src/main/java/com/nononsenseapps/filepicker/NewFileFragment.java
@@ -12,13 +12,13 @@ import android.support.annotation.Nullable;
 import android.support.v4.app.FragmentManager;
 import android.text.TextUtils;
 
-public class NewFolderFragment extends NewItemFragment {
+public class NewFileFragment extends NewItemFragment {
 
-    private static final String TAG = "new_folder_fragment";
+    private static final String TAG = "new_file_fragment";
 
     public static void showDialog(@NonNull final FragmentManager fm,
                                   @Nullable final OnNewItemListener listener) {
-        NewItemFragment d = new NewFolderFragment();
+        NewItemFragment d = new NewFileFragment();
         d.setListener(listener);
         d.show(fm, TAG);
     }
@@ -38,11 +38,11 @@ public class NewFolderFragment extends NewItemFragment {
 
     @Override
     protected int getTitle() {
-        return R.string.nnf_new_folder;
+        return R.string.nnf_new_file;
     }
 
     @Override
     protected boolean isFile() {
-        return false;
+        return true;
     }
 }

--- a/library/src/main/java/com/nononsenseapps/filepicker/NewItemFragment.java
+++ b/library/src/main/java/com/nononsenseapps/filepicker/NewItemFragment.java
@@ -11,8 +11,10 @@ import android.app.Activity;
 import android.app.Dialog;
 import android.content.DialogInterface;
 import android.os.Bundle;
+import android.support.annotation.LayoutRes;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
+import android.support.annotation.StringRes;
 import android.support.v4.app.DialogFragment;
 import android.support.v7.app.AlertDialog;
 import android.text.Editable;
@@ -23,13 +25,13 @@ import android.widget.EditText;
 
 public abstract class NewItemFragment extends DialogFragment {
 
-    private OnNewFolderListener listener = null;
+    private OnNewItemListener listener = null;
 
     public NewItemFragment() {
         super();
     }
 
-    public void setListener(@Nullable final OnNewFolderListener listener) {
+    public void setListener(@Nullable final OnNewItemListener listener) {
         this.listener = listener;
     }
 
@@ -42,8 +44,8 @@ public abstract class NewItemFragment extends DialogFragment {
     @Override
     public Dialog onCreateDialog(Bundle savedInstanceState) {
         AlertDialog.Builder builder = new AlertDialog.Builder(getActivity());
-        builder.setView(R.layout.nnf_dialog_folder_name)
-                .setTitle(R.string.nnf_new_folder)
+        builder.setView(getLayout())
+                .setTitle(getTitle())
                 .setNegativeButton(android.R.string.cancel,
                         null)
                 .setPositiveButton(android.R.string.ok,
@@ -80,7 +82,7 @@ public abstract class NewItemFragment extends DialogFragment {
                         String itemName = editText.getText().toString();
                         if (validateName(itemName)) {
                             if (listener != null) {
-                                listener.onNewFolder(itemName);
+                                listener.onNewItem(itemName, isFile());
                             }
                             dialog.dismiss();
                         }
@@ -112,13 +114,19 @@ public abstract class NewItemFragment extends DialogFragment {
 
     protected abstract boolean validateName(final String itemName);
 
-    public interface OnNewFolderListener {
+    protected abstract @LayoutRes int getLayout();
+
+    protected abstract @StringRes int getTitle();
+
+    protected abstract boolean isFile();
+
+    public interface OnNewItemListener {
         /**
          * Name is validated to be non-null, non-empty and not containing any
          * slashes.
          *
          * @param name The name of the folder the user wishes to create.
          */
-        void onNewFolder(@NonNull final String name);
+        void onNewItem(@NonNull final String name, final boolean isFile);
     }
 }

--- a/library/src/main/res/drawable/nnf_ic_note_add_white_24dp.xml
+++ b/library/src/main/res/drawable/nnf_ic_note_add_white_24dp.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="24dp"
+        android:height="24dp"
+        android:viewportWidth="24.0"
+        android:viewportHeight="24.0">
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:pathData="M14,2L6,2c-1.1,0 -1.99,0.9 -1.99,2L4,20c0,1.1 0.89,2 1.99,2L18,22c1.1,0 2,-0.9 2,-2L20,8l-6,-6zM16,16h-3v3h-2v-3L8,16v-2h3v-3h2v3h3v2zM13,9L13,3.5L18.5,9L13,9z"/>
+</vector>

--- a/library/src/main/res/menu/picker_actions.xml
+++ b/library/src/main/res/menu/picker_actions.xml
@@ -13,4 +13,10 @@
         android:orderInCategory="1"
         android:icon="@drawable/nnf_ic_create_new_folder_white_24dp"
         />
+    <item android:id="@+id/nnf_action_createfile"
+          android:title="@string/nnf_new_file"
+          app:showAsAction="always"
+          android:orderInCategory="2"
+          android:icon="@drawable/nnf_ic_note_add_white_24dp"
+        />
 </menu>

--- a/library/src/main/res/values/strings.xml
+++ b/library/src/main/res/values/strings.xml
@@ -6,6 +6,7 @@
 
 <resources>
     <string name="nnf_new_folder">New folder</string>
+    <string name="nnf_new_file">New file</string>
     <string name="nnf_create_folder_error">Failed to create folder</string>
     <string name="nnf_name">Name</string>
     <string name="nnf_select_something_first">Please select something first</string>


### PR DESCRIPTION
Name of a new (non-existing) file name can be specified, e.g. when the file should be created by the app. This is presented to the user as additional menu item and has to be activated:
intent.putExtra(FilePickerActivity.EXTRA_ALLOW_CREATE_FILE, true);