### PR TITLE
Fixed RuntimeException with empty state in onSaveInstanceState

### DIFF
--- a/library/src/main/java/com/nononsenseapps/filepicker/AbstractFilePickerActivity.java
+++ b/library/src/main/java/com/nononsenseapps/filepicker/AbstractFilePickerActivity.java
@@ -116,6 +116,7 @@ public abstract class AbstractFilePickerActivity<T> extends AppCompatActivity
 
     @Override
     public void onSaveInstanceState(Bundle b) {
+        b.putString("WORKAROUND_FOR_BUG_19917_KEY", "WORKAROUND_FOR_BUG_19917_VALUE");
         super.onSaveInstanceState(b);
     }
 

--- a/library/src/main/java/com/nononsenseapps/filepicker/AbstractFilePickerFragment.java
+++ b/library/src/main/java/com/nononsenseapps/filepicker/AbstractFilePickerFragment.java
@@ -497,13 +497,13 @@ public abstract class AbstractFilePickerFragment<T> extends Fragment
 
     @Override
     public void onSaveInstanceState(Bundle b) {
-        super.onSaveInstanceState(b);
         b.putString(KEY_CURRENT_PATH, mCurrentPath.toString());
         b.putBoolean(KEY_ALLOW_MULTIPLE, allowMultiple);
         b.putBoolean(KEY_ALLOW_EXISTING_FILE, allowExistingFile);
         b.putBoolean(KEY_ALLOW_DIR_CREATE, allowCreateDir);
         b.putBoolean(KEY_SINGLE_CLICK, singleClick);
         b.putInt(KEY_MODE, mode);
+        super.onSaveInstanceState(b);
     }
 
     @Override


### PR DESCRIPTION
This adds a dummy value to the state if it is empty in `AbstractFilePickerActivity.java`.
This also first adds the values to the state, and then saves (instead of the other way around) in `AbstractFilePickerFragment.java`